### PR TITLE
feat(vnc): Run a VNC server to allow remote viewing

### DIFF
--- a/node-firefox/Dockerfile
+++ b/node-firefox/Dockerfile
@@ -10,9 +10,15 @@ RUN apk --update --no-cache add \
       dbus \
       firefox \
       ttf-freefont \
-      xvfb
+      xvfb \
+    && echo 'http://dl-cdn.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories \
+    && echo 'http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories \
+    && echo 'http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories \
+    && apk --update --no-cache add x11vnc
 
 RUN dbus-uuidgen > /var/lib/dbus/machine-id
+
+EXPOSE 5900
 
 COPY scripts/entrypoint.sh $SELENIUM_DIR
 ENTRYPOINT ["./entrypoint.sh"]

--- a/node-firefox/scripts/entrypoint.sh
+++ b/node-firefox/scripts/entrypoint.sh
@@ -16,6 +16,10 @@ rm /tmp/.X99-lock
 export DISPLAY=":99.0"
 Xvfb $DISPLAY -screen 0 1280x1024x24 -ac -extension RANDR  &
 
+# Run a VNC server
+# (Runs in a loop to ensure it restarts if it crashes)
+sh -c "while true; do x11vnc -forever -display $DISPLAY -shared -forever -nopw; done" &
+
 java -jar selenium-server-standalone-$SELENIUM_VERSION.jar \
      -role node \
      -hub http://hub:$HUB_PORT/grid/register \


### PR DESCRIPTION
Adds a VNC viewer to allow remote viewing.

Makes it easier to debug test failures since you can see the browser as the test is running.